### PR TITLE
Add Zephyr driver skeleton for BMX160

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+zephyr_include_directories(drivers/sensor/bmx160)
+add_subdirectory(drivers/sensor/bmx160)

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,5 @@
+menu "BMX160 driver"
+
+source "drivers/sensor/bmx160/Kconfig"
+
+endmenu

--- a/README.md
+++ b/README.md
@@ -90,5 +90,8 @@ int main(void)
 * [ModusToolbox™ Software](https://github.com/Infineon/modustoolbox-software)
 * [PSoC™ 6 Resources - KBA223067](https://community.cypress.com/docs/DOC-14644)
 
+### Zephyr Driver
+This repository also provides a basic Zephyr driver implementation located in `drivers/sensor/bmx160`. Enable CONFIG_BMX160 to use it.
+
 ---
 © Cypress Semiconductor Corporation (an Infineon company) or an affiliate of Cypress Semiconductor Corporation, 2021-2023.

--- a/drivers/sensor/bmx160/CMakeLists.txt
+++ b/drivers/sensor/bmx160/CMakeLists.txt
@@ -1,0 +1,5 @@
+zephyr_library()
+
+zephyr_library_sources(
+  bmx160.c
+)

--- a/drivers/sensor/bmx160/Kconfig
+++ b/drivers/sensor/bmx160/Kconfig
@@ -1,0 +1,6 @@
+menuconfig BMX160
+    bool "BMX160 sensor"
+    select BMI160
+    select BMM150
+    help
+      Enable driver for the Bosch BMX160 9-axis sensor.

--- a/drivers/sensor/bmx160/bmx160.c
+++ b/drivers/sensor/bmx160/bmx160.c
@@ -1,0 +1,104 @@
+#include "bmx160.h"
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(bmx160, CONFIG_SENSOR_LOG_LEVEL);
+
+static int bmx160_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+    struct bmx160_data *data = dev->data;
+    const struct bmx160_config *cfg = dev->config;
+
+    /* Read acceleration, gyroscope and magnetometer data from sensor */
+    uint8_t buf[20];
+
+    /* This driver expects BMI160 + BMM150 data block starting at accel registers. */
+    if (i2c_burst_read_dt(&cfg->i2c, 0x12, buf, sizeof(buf)) < 0) {
+        return -EIO;
+    }
+
+    /* Convert raw values to sensor_value (placeholder conversion) */
+    for (int i = 0; i < 3; i++) {
+        int16_t raw_a = (int16_t)((buf[i*2+0] << 8) | buf[i*2+1]);
+        data->accel[i].val1 = raw_a;
+        data->accel[i].val2 = 0;
+    }
+
+    for (int i = 0; i < 3; i++) {
+        int16_t raw_g = (int16_t)((buf[6 + i*2] << 8) | buf[6 + i*2 + 1]);
+        data->gyro[i].val1 = raw_g;
+        data->gyro[i].val2 = 0;
+    }
+
+    for (int i = 0; i < 3; i++) {
+        int16_t raw_m = (int16_t)((buf[12 + i*2] << 8) | buf[12 + i*2 + 1]);
+        data->magn[i].val1 = raw_m;
+        data->magn[i].val2 = 0;
+    }
+
+    return 0;
+}
+
+static int bmx160_channel_get(const struct device *dev, enum sensor_channel chan,
+                              struct sensor_value *val)
+{
+    struct bmx160_data *data = dev->data;
+
+    switch (chan) {
+    case SENSOR_CHAN_ACCEL_X:
+    case SENSOR_CHAN_ACCEL_Y:
+    case SENSOR_CHAN_ACCEL_Z:
+        *val = data->accel[chan - SENSOR_CHAN_ACCEL_X];
+        return 0;
+    case SENSOR_CHAN_GYRO_X:
+    case SENSOR_CHAN_GYRO_Y:
+    case SENSOR_CHAN_GYRO_Z:
+        *val = data->gyro[chan - SENSOR_CHAN_GYRO_X];
+        return 0;
+    case SENSOR_CHAN_MAGN_X:
+    case SENSOR_CHAN_MAGN_Y:
+    case SENSOR_CHAN_MAGN_Z:
+        *val = data->magn[chan - SENSOR_CHAN_MAGN_X];
+        return 0;
+    default:
+        return -ENOTSUP;
+    }
+}
+
+static int bmx160_init(const struct device *dev)
+{
+    const struct bmx160_config *cfg = dev->config;
+
+    if (!device_is_ready(cfg->i2c.bus)) {
+        return -ENODEV;
+    }
+
+    /* Reset sensor */
+    uint8_t cmd[2] = {0x7E, 0xB6};
+    if (i2c_write_dt(&cfg->i2c, cmd, sizeof(cmd)) < 0) {
+        return -EIO;
+    }
+
+    k_msleep(100);
+
+    /* Additional configuration would normally be done here */
+
+    return 0;
+}
+
+static const struct sensor_driver_api bmx160_api = {
+    .sample_fetch = bmx160_sample_fetch,
+    .channel_get = bmx160_channel_get,
+};
+
+#define BMX160_INST(inst) \
+    static struct bmx160_data bmx160_data_##inst; \
+    static const struct bmx160_config bmx160_config_##inst = { \
+        .i2c = I2C_DT_SPEC_INST_GET(inst), \
+    }; \
+    DEVICE_DT_INST_DEFINE(inst, bmx160_init, NULL, \
+                          &bmx160_data_##inst, &bmx160_config_##inst, \
+                          POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, \
+                          &bmx160_api);
+
+DT_INST_FOREACH_STATUS_OKAY(BMX160_INST)
+

--- a/drivers/sensor/bmx160/bmx160.h
+++ b/drivers/sensor/bmx160/bmx160.h
@@ -1,0 +1,18 @@
+#ifndef ZEPHYR_DRIVERS_SENSOR_BMX160_BMX160_H_
+#define ZEPHYR_DRIVERS_SENSOR_BMX160_BMX160_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+
+struct bmx160_config {
+    struct i2c_dt_spec i2c;
+};
+
+struct bmx160_data {
+    struct sensor_value accel[3];
+    struct sensor_value gyro[3];
+    struct sensor_value magn[3];
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_BMX160_BMX160_H_ */


### PR DESCRIPTION
## Summary
- add Zephyr oriented driver under `drivers/sensor/bmx160`
- provide build system entries (`CMakeLists.txt`, `Kconfig`)
- document Zephyr support in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d36f8ab44832ea5dad020578089ff