### PR TITLE
Add BMX160 initialization and config options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,2 @@
-zephyr_include_directories(drivers/sensor/bmx160)
-add_subdirectory(drivers/sensor/bmx160)
+zephyr_include_directories_ifdef(CONFIG_BMX160 drivers/sensor/bmx160)
+add_subdirectory_ifdef(CONFIG_BMX160 drivers/sensor/bmx160)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,37 @@ int main(void)
 * [PSoC™ 6 Resources - KBA223067](https://community.cypress.com/docs/DOC-14644)
 
 ### Zephyr Driver
-This repository also provides a basic Zephyr driver implementation located in `drivers/sensor/bmx160`. Enable CONFIG_BMX160 to use it.
+This repository also provides a basic Zephyr driver implementation located in `drivers/sensor/bmx160`. The driver is standalone and does not depend on the separate BMI160 or BMM150 drivers. Enable `CONFIG_BMX160` to use it.
+The driver exposes acceleration, gyro and magnetometer data through the standard
+`SENSOR_CHAN_*_XYZ` channels so existing application code written for the
+upstream BMI160 driver can be reused without modifications.
+
+Default ranges and output data rates can be configured via dedicated Kconfig
+options (`BMX160_ACCEL_RANGE_*`, `BMX160_GYRO_RANGE_*`,
+`BMX160_ACCEL_ODR_*` and `BMX160_GYRO_ODR_*`).
+
+### Zephyr Module Integration
+This repository can be added to a Zephyr workspace as an external module. In
+your ``west.yml`` manifest add a project entry pointing to this repository. When
+``west update`` is run, the build system will automatically detect the module via
+the ``zephyr/module.yml`` file.
+
+Enable the driver in your application configuration:
+
+```
+CONFIG_BMX160=y
+```
+
+Then declare the device in your devicetree overlay, for example:
+
+```
+&i2c1 {
+    bmx160@68 {
+        compatible = "bosch,bmx160";
+        reg = <0x68>;
+    };
+};
+```
 
 ---
 © Cypress Semiconductor Corporation (an Infineon company) or an affiliate of Cypress Semiconductor Corporation, 2021-2023.

--- a/drivers/sensor/bmx160/CMakeLists.txt
+++ b/drivers/sensor/bmx160/CMakeLists.txt
@@ -1,5 +1,3 @@
 zephyr_library()
 
-zephyr_library_sources(
-  bmx160.c
-)
+zephyr_library_sources_ifdef(CONFIG_BMX160 bmx160.c)

--- a/drivers/sensor/bmx160/Kconfig
+++ b/drivers/sensor/bmx160/Kconfig
@@ -1,6 +1,88 @@
 menuconfig BMX160
     bool "BMX160 sensor"
-    select BMI160
-    select BMM150
+    default y
+    depends on DT_HAS_BOSCH_BMX160_ENABLED
+    select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMX160),i2c)
     help
       Enable driver for the Bosch BMX160 9-axis sensor.
+
+if BMX160
+
+choice
+    prompt "Accelerometer range"
+    default BMX160_ACCEL_RANGE_2G
+
+config BMX160_ACCEL_RANGE_2G
+    bool "2G"
+
+config BMX160_ACCEL_RANGE_4G
+    bool "4G"
+
+config BMX160_ACCEL_RANGE_8G
+    bool "8G"
+
+config BMX160_ACCEL_RANGE_16G
+    bool "16G"
+endchoice
+
+choice
+    prompt "Gyroscope range"
+    default BMX160_GYRO_RANGE_2000DPS
+
+config BMX160_GYRO_RANGE_2000DPS
+    bool "2000 DPS"
+
+config BMX160_GYRO_RANGE_1000DPS
+    bool "1000 DPS"
+
+config BMX160_GYRO_RANGE_500DPS
+    bool "500 DPS"
+
+config BMX160_GYRO_RANGE_250DPS
+    bool "250 DPS"
+
+config BMX160_GYRO_RANGE_125DPS
+    bool "125 DPS"
+endchoice
+
+choice
+    prompt "Accelerometer ODR"
+    default BMX160_ACCEL_ODR_100
+
+config BMX160_ACCEL_ODR_50
+    bool "50 Hz"
+
+config BMX160_ACCEL_ODR_100
+    bool "100 Hz"
+
+config BMX160_ACCEL_ODR_200
+    bool "200 Hz"
+
+config BMX160_ACCEL_ODR_400
+    bool "400 Hz"
+
+config BMX160_ACCEL_ODR_800
+    bool "800 Hz"
+endchoice
+
+choice
+    prompt "Gyroscope ODR"
+    default BMX160_GYRO_ODR_100
+
+config BMX160_GYRO_ODR_50
+    bool "50 Hz"
+
+config BMX160_GYRO_ODR_100
+    bool "100 Hz"
+
+config BMX160_GYRO_ODR_200
+    bool "200 Hz"
+
+config BMX160_GYRO_ODR_400
+    bool "400 Hz"
+
+config BMX160_GYRO_ODR_800
+    bool "800 Hz"
+endchoice
+
+endif # BMX160

--- a/drivers/sensor/bmx160/bmx160.c
+++ b/drivers/sensor/bmx160/bmx160.c
@@ -1,4 +1,12 @@
+/* Bosch BMX160 9-axis sensor driver
+ *
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "bmx160.h"
+#include <string.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(bmx160, CONFIG_SENSOR_LOG_LEVEL);
@@ -11,8 +19,7 @@ static int bmx160_sample_fetch(const struct device *dev, enum sensor_channel cha
     /* Read acceleration, gyroscope and magnetometer data from sensor */
     uint8_t buf[20];
 
-    /* This driver expects BMI160 + BMM150 data block starting at accel registers. */
-    if (i2c_burst_read_dt(&cfg->i2c, 0x12, buf, sizeof(buf)) < 0) {
+    if (i2c_burst_read_dt(&cfg->i2c, BMX160_REG_DATA_START, buf, sizeof(buf)) < 0) {
         return -EIO;
     }
 
@@ -44,15 +51,24 @@ static int bmx160_channel_get(const struct device *dev, enum sensor_channel chan
     struct bmx160_data *data = dev->data;
 
     switch (chan) {
+    case SENSOR_CHAN_ACCEL_XYZ:
+        memcpy(val, data->accel, sizeof(data->accel));
+        return 0;
     case SENSOR_CHAN_ACCEL_X:
     case SENSOR_CHAN_ACCEL_Y:
     case SENSOR_CHAN_ACCEL_Z:
         *val = data->accel[chan - SENSOR_CHAN_ACCEL_X];
         return 0;
+    case SENSOR_CHAN_GYRO_XYZ:
+        memcpy(val, data->gyro, sizeof(data->gyro));
+        return 0;
     case SENSOR_CHAN_GYRO_X:
     case SENSOR_CHAN_GYRO_Y:
     case SENSOR_CHAN_GYRO_Z:
         *val = data->gyro[chan - SENSOR_CHAN_GYRO_X];
+        return 0;
+    case SENSOR_CHAN_MAGN_XYZ:
+        memcpy(val, data->magn, sizeof(data->magn));
         return 0;
     case SENSOR_CHAN_MAGN_X:
     case SENSOR_CHAN_MAGN_Y:
@@ -73,14 +89,42 @@ static int bmx160_init(const struct device *dev)
     }
 
     /* Reset sensor */
-    uint8_t cmd[2] = {0x7E, 0xB6};
+    uint8_t cmd[2] = {BMX160_REG_CMD, BMX160_CMD_SOFT_RESET};
     if (i2c_write_dt(&cfg->i2c, cmd, sizeof(cmd)) < 0) {
         return -EIO;
     }
 
     k_msleep(100);
 
-    /* Additional configuration would normally be done here */
+    uint8_t chip;
+    if (i2c_reg_read_byte_dt(&cfg->i2c, BMX160_REG_CHIPID, &chip) < 0) {
+        return -EIO;
+    }
+
+    if (chip != BMX160_CHIP_ID) {
+        LOG_ERR("Unexpected chip id 0x%x", chip);
+        return -ENODEV;
+    }
+
+    if (i2c_reg_write_byte_dt(&cfg->i2c, BMX160_REG_ACC_RANGE, BMX160_DEFAULT_RANGE_ACC) < 0) {
+        return -EIO;
+    }
+
+    if (i2c_reg_write_byte_dt(&cfg->i2c, BMX160_REG_GYR_RANGE, BMX160_DEFAULT_RANGE_GYR) < 0) {
+        return -EIO;
+    }
+
+    if (i2c_reg_update_byte_dt(&cfg->i2c, BMX160_REG_ACC_CONF,
+                               BMX160_ACC_CONF_ODR_MASK,
+                               BMX160_DEFAULT_ODR_ACC) < 0) {
+        return -EIO;
+    }
+
+    if (i2c_reg_update_byte_dt(&cfg->i2c, BMX160_REG_GYR_CONF,
+                               BMX160_GYR_CONF_ODR_MASK,
+                               BMX160_DEFAULT_ODR_GYR) < 0) {
+        return -EIO;
+    }
 
     return 0;
 }

--- a/drivers/sensor/bmx160/bmx160.h
+++ b/drivers/sensor/bmx160/bmx160.h
@@ -1,9 +1,94 @@
+/* Bosch BMX160 driver internal API
+ *
+ * Copyright (c) 2023 Infineon Technologies AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ZEPHYR_DRIVERS_SENSOR_BMX160_BMX160_H_
 #define ZEPHYR_DRIVERS_SENSOR_BMX160_BMX160_H_
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/util.h>
+
+#define DT_DRV_COMPAT bosch_bmx160
+
+/* Common register addresses */
+#define BMX160_REG_CHIPID     0x00
+#define BMX160_REG_ACC_CONF   0x40
+#define BMX160_REG_ACC_RANGE  0x41
+#define BMX160_REG_GYR_CONF   0x42
+#define BMX160_REG_GYR_RANGE  0x43
+#define BMX160_REG_DATA_START 0x12
+#define BMX160_REG_CMD        0x7E
+#define BMX160_SPI_START      0x7F
+
+#define BMX160_CMD_SOFT_RESET 0xB6
+#define BMX160_CHIP_ID        0xD8
+
+#define BMX160_ACC_CONF_ODR_MASK 0x0F
+#define BMX160_GYR_CONF_ODR_MASK 0x0F
+
+/* Range register values */
+#define BMX160_ACC_RANGE_2G          0x3
+#define BMX160_ACC_RANGE_4G          0x5
+#define BMX160_ACC_RANGE_8G          0x8
+#define BMX160_ACC_RANGE_16G         0xC
+
+#define BMX160_GYR_RANGE_2000DPS     0x0
+#define BMX160_GYR_RANGE_1000DPS     0x1
+#define BMX160_GYR_RANGE_500DPS      0x2
+#define BMX160_GYR_RANGE_250DPS      0x3
+#define BMX160_GYR_RANGE_125DPS      0x4
+
+/* Default configuration values derived from Kconfig */
+#if defined(CONFIG_BMX160_ACCEL_RANGE_4G)
+#define BMX160_DEFAULT_RANGE_ACC  BMX160_ACC_RANGE_4G
+#elif defined(CONFIG_BMX160_ACCEL_RANGE_8G)
+#define BMX160_DEFAULT_RANGE_ACC  BMX160_ACC_RANGE_8G
+#elif defined(CONFIG_BMX160_ACCEL_RANGE_16G)
+#define BMX160_DEFAULT_RANGE_ACC  BMX160_ACC_RANGE_16G
+#else
+#define BMX160_DEFAULT_RANGE_ACC  BMX160_ACC_RANGE_2G
+#endif
+
+#if defined(CONFIG_BMX160_GYRO_RANGE_1000DPS)
+#define BMX160_DEFAULT_RANGE_GYR  BMX160_GYR_RANGE_1000DPS
+#elif defined(CONFIG_BMX160_GYRO_RANGE_500DPS)
+#define BMX160_DEFAULT_RANGE_GYR  BMX160_GYR_RANGE_500DPS
+#elif defined(CONFIG_BMX160_GYRO_RANGE_250DPS)
+#define BMX160_DEFAULT_RANGE_GYR  BMX160_GYR_RANGE_250DPS
+#elif defined(CONFIG_BMX160_GYRO_RANGE_125DPS)
+#define BMX160_DEFAULT_RANGE_GYR  BMX160_GYR_RANGE_125DPS
+#else
+#define BMX160_DEFAULT_RANGE_GYR  BMX160_GYR_RANGE_2000DPS
+#endif
+
+#if defined(CONFIG_BMX160_ACCEL_ODR_50)
+#define BMX160_DEFAULT_ODR_ACC   7
+#elif defined(CONFIG_BMX160_ACCEL_ODR_200)
+#define BMX160_DEFAULT_ODR_ACC   9
+#elif defined(CONFIG_BMX160_ACCEL_ODR_400)
+#define BMX160_DEFAULT_ODR_ACC   10
+#elif defined(CONFIG_BMX160_ACCEL_ODR_800)
+#define BMX160_DEFAULT_ODR_ACC   11
+#else
+#define BMX160_DEFAULT_ODR_ACC   8
+#endif
+
+#if defined(CONFIG_BMX160_GYRO_ODR_50)
+#define BMX160_DEFAULT_ODR_GYR   7
+#elif defined(CONFIG_BMX160_GYRO_ODR_200)
+#define BMX160_DEFAULT_ODR_GYR   9
+#elif defined(CONFIG_BMX160_GYRO_ODR_400)
+#define BMX160_DEFAULT_ODR_GYR   10
+#elif defined(CONFIG_BMX160_GYRO_ODR_800)
+#define BMX160_DEFAULT_ODR_GYR   11
+#else
+#define BMX160_DEFAULT_ODR_GYR   8
+#endif
 
 struct bmx160_config {
     struct i2c_dt_spec i2c;

--- a/dts/bindings/sensor/bosch,bmx160-i2c.yaml
+++ b/dts/bindings/sensor/bosch,bmx160-i2c.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: BMX160 9-axis sensor connected via I2C
+
+compatible: "bosch,bmx160"
+
+include: ["i2c-device.yaml", "bosch,bmx160.yaml"]

--- a/dts/bindings/sensor/bosch,bmx160.yaml
+++ b/dts/bindings/sensor/bosch,bmx160.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: Bosch BMX160 9-axis sensor
+
+include: sensor-device.yaml
+
+properties:
+  int-gpios:
+    type: phandle-array
+    required: false
+    description: |
+      Connection for INT1 used by the BMI160 part of the sensor.
+  drdy-gpios:
+    type: phandle-array
+    required: false
+    description: |
+      Data ready pin of the internal BMM150 magnetometer.

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: bmx160
+build:
+  cmake: .
+  kconfig: Kconfig


### PR DESCRIPTION
## Summary
- expose register definitions and defaults in `bmx160.h`
- provide accelerometer/gyro range and ODR choices in Kconfig
- reset the sensor and program ranges/ODR in `bmx160_init`
- document available Kconfig options in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d395422d8832eabb3714a7bf68306